### PR TITLE
nuxt.jsのバージョンアップによって静的生成出来なくなったので修正

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -9,10 +9,12 @@ const sourceFileArrayReplaced = sourceFileArray.sourceFileArray.map(
 export default {
   mode: 'universal',
   srcDir: 'src/',
+  target: 'static',
   generate: {
+    crawler: false,
     routes() {
        return sourceFileArrayReplaced.map(sourceFileArray => {
-         return `article/${sourceFileArray}`
+         return `/article/${sourceFileArray}/`
        })
      }
   },


### PR DESCRIPTION
#6 

* nuxt自体に実装されたルーティング機能を停止
* routsの渡し方を微調整（最後の `/` を追加）
* `target: 'static',` を追記
